### PR TITLE
Make a helper for PKCS12 packaging

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.7.0
+current_version = 1.8.0
 commit = False
 tag = False
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "libpvarki"
-version = "1.7.0"
+version = "1.8.0"
 description = "Common helpers like standard logging init"
 authors = ["Eero af Heurlin <eero.afheurlin@iki.fi>"]
 homepage = "https://github.com/pvarki/python-libpvarki/"

--- a/src/libpvarki/__init__.py
+++ b/src/libpvarki/__init__.py
@@ -1,2 +1,2 @@
 """ Common helpers like standard logging init """
-__version__ = "1.7.0"  # NOTE Use `bump2version --config-file patch` to bump versions correctly
+__version__ = "1.8.0"  # NOTE Use `bump2version --config-file patch` to bump versions correctly

--- a/src/libpvarki/mtlshelp/pkcs12.py
+++ b/src/libpvarki/mtlshelp/pkcs12.py
@@ -1,0 +1,110 @@
+"""Helper to convert PEM to PKCS12 (legacy format)"""
+from typing import Optional, Sequence, Union, cast
+import logging
+from pathlib import Path
+
+from libadvian.binpackers import ensure_utf8, ensure_str
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.serialization import (
+    load_pem_private_key,
+    pkcs12,
+    PrivateFormat,
+)
+from cryptography.hazmat.primitives.asymmetric import (
+    dsa,
+    ec,
+    ed448,
+    ed25519,
+    rsa,
+)
+
+LOGGER = logging.getLogger(__name__)
+PKCS12KEYTYPES = (
+    rsa.RSAPrivateKey,
+    dsa.DSAPrivateKey,
+    ec.EllipticCurvePrivateKey,
+    ed25519.Ed25519PrivateKey,
+    ed448.Ed448PrivateKey,
+)
+
+
+def serialize_legacy_pkcs12(
+    friendlyname: bytes,
+    key: Optional[pkcs12.PKCS12PrivateKeyTypes],
+    main_cert: Optional[x509.Certificate],
+    other_certs: Optional[Sequence[x509.Certificate]],
+    password: bytes,
+) -> bytes:
+    """serialize_key_and_certificates but using the more compatible legacy format"""
+    LOGGER.debug("key={}".format(key))
+    LOGGER.debug("main_cert={}".format(main_cert))
+    LOGGER.debug("other_certs={}".format(other_certs))
+
+    encryption = (
+        PrivateFormat.PKCS12.encryption_builder()
+        .kdf_rounds(50000)
+        .key_cert_algorithm(pkcs12.PBES.PBESv1SHA1And3KeyTripleDESCBC)  # nosec
+        .hmac_hash(hashes.SHA1())  # nosec
+        .build(password)
+    )
+
+    return pkcs12.serialize_key_and_certificates(friendlyname, key, main_cert, other_certs, encryption)
+
+
+def get_src_bytes(certsrc: Union[bytes, Path, str]) -> bytes:
+    """Get the specified source as bytes can be path/pathlike or just the bytes as-is"""
+    if isinstance(certsrc, Path):
+        return certsrc.read_bytes()
+    if ensure_str(certsrc).startswith("-----BEGIN "):
+        return ensure_utf8(certsrc)
+    certpath = Path(ensure_str(certsrc))
+    if certpath.exists():
+        return certpath.read_bytes()
+    raise ValueError(f"Could not resolve {certsrc!r}")
+
+
+def convert_pem_to_pkcs12(
+    certsrc: Optional[Union[bytes, Path, str]],
+    keysrc: Optional[Union[bytes, Path, str]],
+    p12password: Union[bytes, str],
+    keypassword: Optional[Union[bytes, str]] = None,
+    friendlyname: Optional[Union[str, bytes]] = None,
+) -> bytes:
+    """Convert PEM to PKCS12 (legacy format), in case of multiple certs first one is the main and rests "CA"s"""
+    if certsrc is None:
+        main_cert = None
+        other_certs = None
+    else:
+        certs = x509.load_pem_x509_certificates(get_src_bytes(certsrc))
+        LOGGER.debug("Found {} certificates".format(len(certs)))
+        if not certs:
+            main_cert = None
+            other_certs = None
+        elif len(certs) > 1:
+            main_cert = certs[0]
+            other_certs = certs[1:]
+        else:
+            main_cert = certs[0]
+            other_certs = None
+
+    if keysrc is None:
+        key = None
+    else:
+        if keypassword is not None:
+            keypassword = ensure_utf8(keypassword)
+        key = load_pem_private_key(get_src_bytes(keysrc), keypassword)
+        LOGGER.debug("Got key {}".format(key))
+        if not isinstance(key, PKCS12KEYTYPES):
+            raise ValueError("Invalid key type for PKCS12")
+
+    if friendlyname is None:
+        friendlyname = b""
+
+    return serialize_legacy_pkcs12(
+        ensure_utf8(friendlyname),
+        cast(Optional[pkcs12.PKCS12PrivateKeyTypes], key),
+        main_cert,
+        other_certs,
+        ensure_utf8(p12password),
+    )

--- a/tests/mtls/test_pkcs12.py
+++ b/tests/mtls/test_pkcs12.py
@@ -1,0 +1,98 @@
+"""Test the pkcs12 helper"""
+from typing import Tuple
+import logging
+from pathlib import Path
+
+import pytest
+from cryptography.hazmat.primitives.serialization.pkcs12 import load_key_and_certificates
+
+from libpvarki.mtlshelp import pkcs12
+
+LOGGER = logging.getLogger(__name__)
+
+# pylint: disable=W0621
+
+
+@pytest.fixture
+def perdir() -> Path:
+    """Get the persistent data dir"""
+    return Path(__file__).parent.parent / "data" / "persistent"
+
+
+@pytest.fixture
+def single_cert_paths(perdir: Path) -> Tuple[Path, Path]:
+    """Paths to the cert and key for single cert (not a chain) PEM"""
+    return (perdir / "public" / "mtlsclient.pem"), (perdir / "private" / "mtlsclient.key")
+
+
+def check_single_cert(pfxbytes: bytes, p12password: bytes, expect_key: bool = True) -> None:
+    """Parse and check"""
+    key, cert, cas = load_key_and_certificates(pfxbytes, p12password)
+    LOGGER.debug("Got key={} cer={} cas={}".format(key, cert, cas))
+    if expect_key:
+        assert key
+        assert cert
+        assert not cas
+    else:
+        assert key is None
+        # Cert without key seems to go to the "other certs" aka "CAs" section
+        assert len(cas) == 1
+
+
+def test_encode_pem_simple_paths(single_cert_paths: Tuple[Path, Path]) -> None:
+    """Single cert and key (Paths)"""
+    cert, key = single_cert_paths
+    pfxbytes = pkcs12.convert_pem_to_pkcs12(cert, key, b"1337", None, "mtlsclient")
+    check_single_cert(pfxbytes, b"1337")
+
+
+def test_encode_pem_simple_pathstr(single_cert_paths: Tuple[Path, Path]) -> None:
+    """Single cert and key (str paths)"""
+    cert, key = single_cert_paths
+    pfxbytes = pkcs12.convert_pem_to_pkcs12(str(cert), str(key), b"1337", None, "mtlsclient")
+    check_single_cert(pfxbytes, b"1337")
+
+
+def test_encode_pem_simple_bytes(single_cert_paths: Tuple[Path, Path]) -> None:
+    """Single cert and key as bytes"""
+    cert, key = single_cert_paths
+    pfxbytes = pkcs12.convert_pem_to_pkcs12(cert.read_bytes(), key.read_bytes(), b"1337", None, "mtlsclient")
+    check_single_cert(pfxbytes, b"1337")
+
+
+def test_encode_pem_simple_strs(single_cert_paths: Tuple[Path, Path]) -> None:
+    """Single cert and key as strings"""
+    cert, key = single_cert_paths
+    pfxbytes = pkcs12.convert_pem_to_pkcs12(cert.read_text(), key.read_text(), b"1337", None, "mtlsclient")
+    check_single_cert(pfxbytes, b"1337")
+
+
+def test_encode_pem_simple_nokey(single_cert_paths: Tuple[Path, Path]) -> None:
+    """Single cert and key (Paths)"""
+    cert, _key = single_cert_paths
+    pfxbytes = pkcs12.convert_pem_to_pkcs12(cert, None, b"1337", None, "mtlsclient")
+    check_single_cert(pfxbytes, b"1337", expect_key=False)
+
+
+def test_encode_pem_chain_nokey(perdir: Path) -> None:
+    """Cert chain without key"""
+    cert_orig = perdir / "public" / "tlsserver_chain.pem"
+    pfxbytes = pkcs12.convert_pem_to_pkcs12(cert_orig, None, b"1337", None, "server")
+    key, cert, cas = load_key_and_certificates(pfxbytes, b"1337")
+    LOGGER.debug("Got key={} cer={} cas={}".format(key, cert, cas))
+    # Cert without key seems to go to the "other certs" aka "CAs" section
+    assert cert is None
+    assert len(cas) == 2
+    assert key is None
+
+
+def test_encode_pem_chain(perdir: Path) -> None:
+    """Cert chain with key"""
+    cert_orig = perdir / "public" / "tlsserver_chain.pem"
+    key_orig = perdir / "private" / "tlsserver.key"
+    pfxbytes = pkcs12.convert_pem_to_pkcs12(cert_orig, key_orig, b"1337", None, "server")
+    key, cert, cas = load_key_and_certificates(pfxbytes, b"1337")
+    LOGGER.debug("Got key={} cer={} cas={}".format(key, cert, cas))
+    assert cert
+    assert len(cas) == 1
+    assert key

--- a/tests/test_libpvarki.py
+++ b/tests/test_libpvarki.py
@@ -4,4 +4,4 @@ from libpvarki import __version__
 
 def test_version() -> None:
     """Make sure version matches expected"""
-    assert __version__ == "1.7.0"
+    assert __version__ == "1.8.0"


### PR DESCRIPTION
A wrapper to `pkcs12.serialize_key_and_certificates` that just uses legacy encryption and a helper to convert PEM files into PKCS12 bundles (`convert_pem_to_pkcs12`)

Fixes #19 