### PR TITLE
Drop dependency on `libadvian`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1202,20 +1202,6 @@ files = [
 ]
 
 [[package]]
-name = "libadvian"
-version = "1.4.0"
-description = "Small helpers that do not warrant their own library"
-optional = false
-python-versions = ">=3.6.2,<4.0"
-files = [
-    {file = "libadvian-1.4.0-py3-none-any.whl", hash = "sha256:f1c41a0c4777c4b3f36e9d94a9fb2c3c76c6fa4bc7922d7002ba9b06ee51888e"},
-    {file = "libadvian-1.4.0.tar.gz", hash = "sha256:433579a941d5a833022000892da73f0e69b4cfed7d538f4224597d61bb19b8cd"},
-]
-
-[package.extras]
-http = ["frozendict (>=2.3,<3.0)", "requests (>=2.28,<3.0)"]
-
-[[package]]
 name = "markdown-it-py"
 version = "3.0.0"
 description = "Python port of markdown-it. Markdown parsing, done right!"
@@ -2286,4 +2272,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "5494842fae8db38dcdead176728118d6e65e75652a9f5c5d80646f8cdf7dc062"
+content-hash = "62c2c37f1e0c01e58f21aebc6296f8879f3ff266e9c004224a974cea79bf60b8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,6 @@ ecs-logging = "^2.0"
 fastapi = ">0.89,<1.0" # caret behaviour on 0.x is to lock to 0.x.*
 pydantic= ">=2.0,<3.0"
 cryptography = ">=41.0"
-libadvian = "^1.4"
 aiohttp = ">=3.10.2,<4.0"
 aiodns = "^3.0"
 brotli = "^1.0"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 """pytest automagics"""
-from typing import Generator, AsyncGenerator
+from typing import AsyncGenerator
 import logging
 from pathlib import Path
 import ssl
@@ -7,10 +7,9 @@ import random
 
 import pytest
 import pytest_asyncio
-from libadvian.testhelpers import nice_tmpdir, monkeysession  # pylint: disable=W0611
-from libadvian.logging import init_logging
 from aiohttp import web
 
+from libpvarki.logging import init_logging
 from libpvarki.mtlshelp import get_ssl_context
 
 init_logging(logging.DEBUG)
@@ -25,14 +24,11 @@ def datadir() -> Path:
     return Path(__file__).parent / "data"
 
 
-@pytest.fixture(scope="session", autouse=True)
-def tls_env_variables(datadir: Path, monkeysession: pytest.MonkeyPatch) -> Generator[pytest.MonkeyPatch, None, None]:
+@pytest.fixture(autouse=True)
+def tls_env_variables(datadir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Set the TLS paths to env"""
-    monkeysession.setenv("PERSISTENT_DATA_PATH", str(datadir / "persistent"))
-    monkeysession.setenv("LOCAL_CA_CERTS_PATH", str(datadir / "ca_public"))
-
-    yield monkeysession
-    # The teardowns are done automagically
+    monkeypatch.setenv("PERSISTENT_DATA_PATH", str(datadir / "persistent"))
+    monkeypatch.setenv("LOCAL_CA_CERTS_PATH", str(datadir / "ca_public"))
 
 
 @pytest_asyncio.fixture()

--- a/tests/mtls/test_helpers.py
+++ b/tests/mtls/test_helpers.py
@@ -23,9 +23,9 @@ LOGGER = logging.getLogger(__name__)
 # pylint: disable=W0621
 
 
-def test_resolve_filepaths(nice_tmpdir: str) -> None:
+def test_resolve_filepaths(tmp_path: Path) -> None:
     """Test the helper"""
-    privpath, pubpath, csrpath = resolve_filepaths(Path(nice_tmpdir), "mytest")
+    privpath, pubpath, csrpath = resolve_filepaths(tmp_path, "mytest")
     assert privpath.name == "mytest.key"
     assert pubpath.name == "mytest.pub"
     assert csrpath.name == "mytest.csr"
@@ -62,25 +62,25 @@ def create_subdirs(datadir: Path) -> Tuple[Path, Path]:
     return privpath, pubpath
 
 
-def test_keypair_create(nice_tmpdir: str) -> None:
+def test_keypair_create(tmp_path: Path) -> None:
     """Test normal create case"""
-    privpath, pubpath = create_subdirs(Path(nice_tmpdir))
+    privpath, pubpath = create_subdirs(tmp_path)
     ckp = create_keypair(privpath, pubpath, ksize=1024)  # small key to save time
     check_keypair(ckp, privpath, pubpath)
 
 
 @pytest.mark.asyncio
-async def test_keypair_create_async(nice_tmpdir: str) -> None:
+async def test_keypair_create_async(tmp_path: Path) -> None:
     """Test the async wrapper"""
-    privpath, pubpath = create_subdirs(Path(nice_tmpdir))
+    privpath, pubpath = create_subdirs(tmp_path)
     ckp = await async_create_keypair(privpath, pubpath, ksize=1024)  # small key to save time
     check_keypair(ckp, privpath, pubpath)
 
 
 @pytest_asyncio.fixture
-async def keypair(nice_tmpdir: str) -> AsyncGenerator[Tuple[KPTYPE, Path, Path], None]:
+async def keypair(tmp_path: Path) -> AsyncGenerator[Tuple[KPTYPE, Path, Path], None]:
     """Fixture to create keypair"""
-    privpath, pubpath = create_subdirs(Path(nice_tmpdir))
+    privpath, pubpath = create_subdirs(tmp_path)
     ckp = await async_create_keypair(privpath, pubpath, ksize=1024)  # small key to save time
     check_keypair(ckp, privpath, pubpath)
     yield ckp, privpath, pubpath


### PR DESCRIPTION
I noticed `libadvian` (only available on Gitlab?) was used for just a handful of things that could either be done with Pytest's builtins, or just inlined here.