### PR TITLE
Add Product Description Pydantic Model

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.0.0
+current_version = 2.0.1
 commit = False
 tag = False
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,6 +48,7 @@ repos:
     hooks:
     - id: bandit
       args: ["--skip=B101"]
+      additional_dependencies: [pbr]
 -   repo: https://github.com/Lucas-C/pre-commit-hooks-markup
     rev: v1.0.1
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "libpvarki"
-version = "2.0.0"
+version = "2.0.1"
 description = "Common helpers like standard logging init"
 authors = ["Eero af Heurlin <eero.afheurlin@iki.fi>"]
 homepage = "https://github.com/pvarki/python-libpvarki/"

--- a/src/libpvarki/__init__.py
+++ b/src/libpvarki/__init__.py
@@ -1,2 +1,2 @@
 """ Common helpers like standard logging init """
-__version__ = "2.0.0"  # NOTE Use `bump2version --config-file patch` to bump versions correctly
+__version__ = "2.0.1"  # NOTE Use `bump2version --config-file patch` to bump versions correctly

--- a/src/libpvarki/schemas/product.py
+++ b/src/libpvarki/schemas/product.py
@@ -104,4 +104,4 @@ class ProductDescription(BaseModel):  # pylint: disable=too-few-public-methods
     class Config:  # pylint: disable=too-few-public-methods
         """Pydantic configs"""
 
-        extra = Extra.forbid
+        extra = "forbid"

--- a/src/libpvarki/schemas/product.py
+++ b/src/libpvarki/schemas/product.py
@@ -92,6 +92,7 @@ class ProductHealthCheckResponse(BaseModel):
         },
     )
 
+
 class ProductDescription(BaseModel):  # pylint: disable=too-few-public-methods
     """Description of a product"""
 

--- a/src/libpvarki/schemas/product.py
+++ b/src/libpvarki/schemas/product.py
@@ -91,3 +91,17 @@ class ProductHealthCheckResponse(BaseModel):
             ],
         },
     )
+
+class ProductDescription(BaseModel):  # pylint: disable=too-few-public-methods
+    """Description of a product"""
+
+    shortname: str = Field(description="Short name for the product, used as slug/key in dicts and urls")
+    title: str = Field(description="Fancy name for the product")
+    icon: Optional[str] = Field(description="URL for icon")
+    description: str = Field(description="Short-ish description of the product")
+    language: str = Field(description="Language of this response")
+
+    class Config:  # pylint: disable=too-few-public-methods
+        """Pydantic configs"""
+
+        extra = Extra.forbid

--- a/tests/test_libpvarki.py
+++ b/tests/test_libpvarki.py
@@ -4,4 +4,4 @@ from libpvarki import __version__
 
 def test_version() -> None:
     """Make sure version matches expected"""
-    assert __version__ == "2.0.0"
+    assert __version__ == "2.0.1"


### PR DESCRIPTION
Added Product Description Pydantic model to shared package (`FIXME` from tak and fp integration)

Note:
```yml
additional_dependencies: [pbr]
```
The above is required for pre-commit failing https://github.com/PyCQA/bandit/issues/735. Don't know why this is coming up now (linked issue is from 2021) but adding the additional dependency seems to fix the issue.